### PR TITLE
Support replay config file

### DIFF
--- a/configs/replay-config-fbgemm.json
+++ b/configs/replay-config-fbgemm.json
@@ -1,0 +1,12 @@
+{
+    "import modules": [
+        "fbgemm_gpu.split_table_batched_embeddings_ops_training"
+    ],
+    "skip nodes": {
+        "aten::_foreach_copy_": "Failed to build function",
+        "aten::_foreach_norm": "Failed to build function",
+        "aten::_foreach_div_": "Failed to build function",
+        "aten::_foreach_mul_": "Failed to build function",
+        "aten::_foreach_add_": "Failed to build function"
+    }
+}

--- a/et_replay/et_replay_utils.py
+++ b/et_replay/et_replay_utils.py
@@ -226,3 +226,13 @@ def build_triton_func(n, resources_dir, async_compile, device):
         func = async_compile.triton("triton_", code, device_str=device)
 
     return func, 0
+
+
+def import_third_party_modules(modules: list[str]):
+    for module in modules:
+        try:
+            print(f"Importing third party module: {module}")
+            __import__(module)
+        except ImportError:
+            print(f"Failed to import {module}")
+            raise


### PR DESCRIPTION
Summary:
Support replay config file

Changed command line option "skip-node-file" to "replay-config" and "update-skip-node-file" to "update-replay-config". 

The skip nodes are not included in replay config file. 

The following is one example of a config file:

{
    "import modules": [
        "fbgemm_gpu.split_table_batched_embeddings_ops_training"
    ],
    "skip nodes": {
        "aten::_foreach_copy_": "Failed to build function",
        "aten::_foreach_norm": "Failed to build function",
        "aten::_foreach_div_": "Failed to build function",
        "aten::_foreach_mul_": "Failed to build function",
        "aten::_foreach_add_": "Failed to build function"
    }
}

"import modules" include the list of third party modules that need be imported to et-replay to make custom ops available in replay. 

"skip nodes" defines the list of ops that need be skipped in replay. The first entry is the node name and the second entry is the reason why it is skipped.

Reviewed By: c-odrin

Differential Revision: D78688077


